### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "pydantic==2.9.2",
         "requests",
         "chromadb==0.5.15",
+        "protobuf<5"
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Protobuf Warning and other deprecations removed and it works with

!pip install git+https://github.com/VedantDeshmukh2/educhain.git --quiet