### PR TITLE
Keep only English characters, numbers, and common punctuation

### DIFF
--- a/archive/models.py
+++ b/archive/models.py
@@ -162,6 +162,7 @@ class UrlLoader:
         return self.clean_string(content)
 
     def clean_string(self, text):
+        text = re.sub(r'[^\x00-\x7F]+', ' ', text)
         text = re.sub(r'\s+', ' ', text)
         return text.strip()
     

--- a/educhain/utils/loaders.py
+++ b/educhain/utils/loaders.py
@@ -27,5 +27,6 @@ class UrlLoader:
         return self.clean_string(content)
 
     def clean_string(self, text):
+        text = re.sub(r'[^\x00-\x7F]+', ' ', text)
         text = re.sub(r'\s+', ' ', text)
         return text.strip()


### PR DESCRIPTION
This line ensures that non-English characters and symbols are removed.

Example:
Input Text: "Hello 😊! This is a test\nwith non-ASCII: 你好 ありがとう"
Output Text: "Hello ! This is a test with non-ASCII"

This makes text cleaner and easier for LLMs to understand and not confuse with other languages.








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced text cleaning process by removing non-ASCII characters from input text.
  
- **Bug Fixes**
	- Improved content extraction quality from URLs by ensuring only ASCII characters are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->