### PR TITLE
Youtube transcript api code fix and video id extraction regex fix 

### DIFF
--- a/educhain/engines/qna_engine.py
+++ b/educhain/engines/qna_engine.py
@@ -658,8 +658,14 @@ class QnAEngine:
 
         return structured_output
 
+    # def _extract_video_id(self, url: str) -> str:
+    #     pattern = r'(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=)?(?:embed\/)?(?:v\/)?(?:shorts\/)?(?:live\/)?(?:feature=player_embedded&v=)?(?:e\/)?(?:\/)?([^\s&amp;?#]+)'
+    #     match = re.search(pattern, url)
+    #     if match:
+    #         return match.group(1)
+    #     raise ValueError("Invalid YouTube URL")
     def _extract_video_id(self, url: str) -> str:
-        pattern = r'(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=)?(?:embed\/)?(?:v\/)?(?:shorts\/)?(?:live\/)?(?:feature=player_embedded&v=)?(?:e\/)?(?:\/)?([^\s&amp;?#]+)'
+        pattern = r'(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/|v\/|shorts\/|live\/|feature=player_embedded&v=|e\/)?([A-Za-z0-9_-]{11})'
         match = re.search(pattern, url)
         if match:
             return match.group(1)
@@ -667,7 +673,7 @@ class QnAEngine:
 
     def _get_youtube_transcript(self, video_id: str, target_language: str = 'en') -> tuple[str, str]:
         try:
-            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+            transcript_list = YouTubeTranscriptApi().list(video_id)
 
             available_languages = [transcript.language_code for transcript in transcript_list]
 


### PR DESCRIPTION
This PR resolves the issue reported — ` AttributeError: type object 'YouTubeTranscriptApi' has no attribute 'list_transcripts' `— by updating YoutubeLoader to instantiate YouTubeTranscriptApi and calling list. 

This PR also resolves the problem : 
` ValueError: Error fetching transcript:Could not retrieve a transcript for the video https://www.youtube.com/watch?v=x7X9w_GI! This is most likely caused by:The video is no longer available` 
------   by updating the regex in `_extract_video_id` method . 

## Testing 
CollabTest Notebook link -  [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/10I-MGrWbJJqwp_HufuX1p9S2xUknneXU?usp=sharing)

